### PR TITLE
Verify iss is a sts url

### DIFF
--- a/lib/ms-id-token-validator.rb
+++ b/lib/ms-id-token-validator.rb
@@ -57,7 +57,10 @@ module MsIdToken
          payload[:iss].nil? ||
          payload[:iat].nil? ||
          payload[:tid].nil? ||
-         payload[:iss].match(/https:\/\/login\.microsoftonline\.com\/(.+)\/v2\.0/).nil?
+         (
+          payload[:iss].match(/https:\/\/login\.microsoftonline\.com\/(.+)\/v2\.0/).nil? &&
+          payload[:iss].match(/https:\/\/sts\.windows\.net\/(.+)\//).nil?
+         )
         raise BadIdTokenPayloadFormat
       end
 


### PR DESCRIPTION
Hey! First of all, thanks for this gem, according to the [payload claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims), the iss can be a sts url, opted to play it safe and don't remove the login.microsoft verification. 

After this patch, this gem is working great.

Thanks!